### PR TITLE
Updating paths in tsconfig.json file

### DIFF
--- a/cypress/e2e/logout_user/top_navigation/top_navigation_address_popup.cy.ts
+++ b/cypress/e2e/logout_user/top_navigation/top_navigation_address_popup.cy.ts
@@ -1,5 +1,4 @@
-import {TopNavigationsAddress} from "../../../support/locators/top_navigation_locators"
-
+import {TopNavigationsAddress} from "@locators/top_navigation_locators"
 
 describe("Logout users: Address Popup", () => {
     beforeEach(() => {

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,11 +1,13 @@
 {
     "compilerOptions": {
       "target": "es5",
+      "module": "NodeNext",  
+      "moduleResolution":"NodeNext" , 
       "lib": ["es5", "dom"],
-      "types": ["cypress", "node"], 
-      "baseUrl": "./cypress/", 
+      "types": ["cypress", "node"],
+      "baseUrl": "./",
       "paths": {
-        "@locators/*": ["/support/locators/*"]
+        "@locators/*":["support/locators/*"]
       }
     },
     "include": ["**/*.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "NodeNext",  
+    "moduleResolution":"NodeNext" ,                      /* Specify what module code is generated. */
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
     "strict": true,                                      /* Enable all strict type-checking options. */


### PR DESCRIPTION
## Description

- [x] Updating the `tsconfig.json`. Changed the paths for "@locators/*" to properly be able to import files within files without needing to use the relative path. 

### Learnings
the "baseUrl" with `tsconfig.json` file is in relationship where the `tsconfig.json` is. Previously this was not working because I thought the location for my `tsconfig.json` file wouldn't matter to set my path, as I had the wrong assumption the basedUrl started from the root of the project. After reading [this](git push --set-upstream origin maintenance/tsconfig_file_update) documentation, I realized the following:

> With "baseUrl": "./", TypeScript will look for files starting at the same folder as the tsconfig.json...